### PR TITLE
Upate GraphLoom to v0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,26 +3,25 @@ plugins {
     id 'java'
     id 'application'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.8.4'
     id 'jacoco'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
 }
 
-group 'com.github.jiefenn8.rdfweaver'
+group = 'com.github.jiefenn8.rdfweaver'
 archivesBaseName = 'rdfweaver-cli'
 description = 'RDFWeaver console - multi-media to semantic graph mapping application.'
 
-version '0.1.0'
+version = '0.1.0'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.15
+targetCompatibility = 1.15
 
 repositories {
     mavenCentral()
-    jcenter()
-    maven {
-        url  "https://dl.bintray.com/jiefenn8/graphloom"
-    }
+}
+
+jacoco {
+    toolVersion = '0.8.7'
 }
 
 sourceSets {
@@ -57,32 +56,33 @@ idea {
 
 dependencies {
     //Test
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
-    testImplementation group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.11.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.13'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.7.7'
     testImplementation group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.1'
 
     //Core
-    implementation group: 'info.picocli', name: 'picocli', version: '4.2.0'
-    implementation group: 'com.github.jiefenn8.graphloom', name: 'graphloom-core', version: '0.4.5'
-    implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
+    implementation group: 'info.picocli', name: 'picocli', version: '4.6.1'
+    implementation group: 'io.github.jiefenn8.graphloom', name: 'graphloom-core', version: '0.5.1'
+    implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'org.apache.jena', name: 'jena-arq', version: '3.5.0'
     implementation group: 'org.apache.jena', name: 'jena-rdfconnection', version: '3.5.0'
 
     //Logging
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.14.1'
 
     //Network
-    implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '6.2.2.jre8'
-    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.20'
-    implementation group: 'com.zaxxer', name: 'HikariCP', version: '3.2.0'
+    implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '9.2.0.jre15'
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.25'
+    implementation group: 'com.zaxxer', name: 'HikariCP', version: '4.0.3'
     implementation group: 'com.oracle.database.jdbc', name: 'ojdbc8', version: '19.3.0.0'
 
     //Annotation Processor
-    annotationProcessor group: 'info.picocli', name: 'picocli-codegen', version: '4.2.0'
+    annotationProcessor group: 'info.picocli', name: 'picocli-codegen', version: '4.6.1'
 }
 
 jacocoTestReport {
+    dependsOn test
     reports {
         xml.enabled true
         html.enabled false
@@ -98,6 +98,9 @@ task integrationTest(type: Test){
 }
 
 task integrationTestReport(type :JacocoReport){
+    dependsOn integrationTest
+    group = 'verification'
+    description = 'Generates code coverage report for the integration test task.'
     sourceSets sourceSets.main
     executionData integrationTest
     reports {
@@ -106,37 +109,6 @@ task integrationTestReport(type :JacocoReport){
     }
 }
 
-check.dependsOn jacocoTestReport
+test.finalizedBy jacocoTestReport
 integrationTest.finalizedBy integrationTestReport
 
-publishing {
-    publications {
-        RDFWeaver(MavenPublication) {
-            from components.java
-            groupId = project.group
-            artifactId = project.archivesBaseName
-            version = project.version
-        }
-    }
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-    pkg {
-        repo = 'rdfweaver'
-        name = project.name
-        userOrg = 'jiefenn8'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/jiefenn8/rdfweaver.git'
-
-        version {
-            name = project.version
-            desc = project.description
-            released = new Date()
-            vcsTag = 'v' + project.version
-        }
-    }
-
-    publications = ['RDFWeaver']
-}

--- a/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/FusekiTDBRemoteTest.java
+++ b/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/FusekiTDBRemoteTest.java
@@ -1,0 +1,60 @@
+package com.github.jiefenn8.rdfweaver.integrationtest.options;
+
+import com.github.jiefenn8.rdfweaver.output.FusekiTDBRemote;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.ResultSetFactory;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.rdfconnection.RDFConnectionFactory;
+import org.apache.jena.system.Txn;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FusekiTDBRemoteTest {
+
+    private final static String HOST = "127.0.0.1";
+    private final static int PORT = 3030;
+    private final static String BASE = "ds";
+    private FusekiTDBRemote fusekiTDBRemote;
+
+    @Before
+    public void setUp() throws Exception {
+        fusekiTDBRemote = new FusekiTDBRemote.Builder(InetAddress.getByName(HOST), PORT, BASE).build();
+    }
+
+    @Test
+    public void GivenPopulatedModel_WhenSave_ThenSaveModel() throws Exception {
+        Resource res = ResourceFactory.createResource("TEST");
+        Model model = ModelFactory.createDefaultModel();
+        model.add(res, ResourceFactory.createProperty("PROPERTY"), ResourceFactory.createStringLiteral("TEST"));
+
+        fusekiTDBRemote.save(model);
+
+        String connStr = new URIBuilder()
+                .setScheme("http")
+                .setHost(HOST)
+                .setPort(PORT)
+                .setPath(BASE)
+                .build()
+                .toASCIIString();
+
+        ResultSet copy;
+        try (RDFConnection conn = RDFConnectionFactory.connect(connStr)) {
+            copy = Txn.calculateRead(conn, () -> {
+                String query = "SELECT (COUNT(*) as ?Triples) WHERE { ?s ?p ?o }";
+                ResultSet rs = conn.query(query).execSelect();
+                return ResultSetFactory.copyResults(rs);
+            });
+        }
+
+        RDFNode node = copy.next().get("Triples");
+        int count = node.asLiteral().getInt();
+        assertThat(count, is(1));
+    }
+}

--- a/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/OutputOptionTest.java
+++ b/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/OutputOptionTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Integration test class for {@code OutputOption}.
+ * Integration test class for {@link OutputOption}.
  */
 @RunWith(JUnitParamsRunner.class)
 public class OutputOptionTest {

--- a/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/R2RMLOptionTest.java
+++ b/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/R2RMLOptionTest.java
@@ -1,9 +1,9 @@
 package com.github.jiefenn8.rdfweaver.integrationtest.options;
 
-import com.github.jiefenn8.graphloom.rdf.parser.R2RMLBuilder;
-import com.github.jiefenn8.graphloom.rdf.r2rml.R2RMLMap;
 import com.github.jiefenn8.rdfweaver.r2rml.R2RMLOption;
 import com.google.common.collect.ImmutableList;
+import io.github.jiefenn8.graphloom.rdf.parser.R2RMLBuilder;
+import io.github.jiefenn8.graphloom.rdf.r2rml.R2RMLMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;

--- a/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/RDFWeaverTest.java
+++ b/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/RDFWeaverTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Integration test class for {@code App}.
+ * Integration test class for {@link RDFWeaver}.
  */
 public class RDFWeaverTest {
 

--- a/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/RDFWeaverTest.java
+++ b/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/RDFWeaverTest.java
@@ -46,7 +46,7 @@ public class RDFWeaverTest {
     private static final String RDB_USER = "sa";
     private static final String RDB_PASS = "YourStrong@Passw0rd";
     private static final String RDB_DB = "testDb";
-    
+
     private RDFWeaver RDFWeaver;
     private Path expectedOutput;
 
@@ -137,16 +137,16 @@ public class RDFWeaverTest {
 
     //Check if running version command does not encounter exception.
     @Test
-    public void GivenVersionCommand_WhenExecute_ThenCompleteRun(){
-        String[] args = new String[] {"--version"};
+    public void GivenVersionCommand_WhenExecute_ThenCompleteRun() {
+        String[] args = new String[]{"--version"};
         int result = RDFWeaver.init(args);
         assertThat(result, is(0));
     }
 
     //Check if running help command does not encounter exception.
     @Test
-    public void GivenHelpCommand_WhenExecute_ThenCompleteRun(){
-        String[] args = new String[] {"--help"};
+    public void GivenHelpCommand_WhenExecute_ThenCompleteRun() {
+        String[] args = new String[]{"--help"};
         int result = RDFWeaver.init(args);
         assertThat(result, is(0));
     }

--- a/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/RDFWeaverTest.java
+++ b/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/RDFWeaverTest.java
@@ -5,6 +5,8 @@ import com.github.jiefenn8.rdfweaver.server.JDBCDriver;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.query.ResultSetFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.rdfconnection.RDFConnectionFactory;
@@ -46,6 +48,7 @@ public class RDFWeaverTest {
     private static final String RDB_USER = "sa";
     private static final String RDB_PASS = "YourStrong@Passw0rd";
     private static final String RDB_DB = "testDb";
+    private static final String FUSEKI_HOST = "127.0.0.1";
 
     private RDFWeaver RDFWeaver;
     private Path expectedOutput;
@@ -79,8 +82,9 @@ public class RDFWeaverTest {
         String[] args = new String[]{"server", driver, db, host, port, user, pass, "r2rml", r2rml, "output"};
 
         RDFWeaver.init(args);
-        boolean result = Files.exists(expectedOutput);
-        assertThat(result, is(true));
+        Model result = ModelFactory.createDefaultModel();
+        result.read(expectedOutput.toString(), "TURTLE");
+        assertThat(result.size(), is(2L));
     }
 
     @Test
@@ -98,7 +102,7 @@ public class RDFWeaverTest {
         String r2rml = "--file=" + r2rmlFile;
 
         //Output params
-        String fHost = RDB_HOST;
+        String fHost = FUSEKI_HOST;
         String fusekiHost = "--host" + DELIMITER + fHost;
         int fPort = 3030;
         String fusekiPort = "--port" + DELIMITER + fPort;

--- a/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/ServerOptionTest.java
+++ b/src/integration-test/java/com/github/jiefenn8/rdfweaver/integrationtest/options/ServerOptionTest.java
@@ -1,11 +1,11 @@
 package com.github.jiefenn8.rdfweaver.integrationtest.options;
 
-import com.github.jiefenn8.graphloom.api.InputSource;
 import com.github.jiefenn8.rdfweaver.server.JDBCDriver;
 import com.github.jiefenn8.rdfweaver.server.ServerOption;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.jiefenn8.graphloom.api.InputSource;
 import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;

--- a/src/main/java/com/github/jiefenn8/rdfweaver/RDFWeaver.java
+++ b/src/main/java/com/github/jiefenn8/rdfweaver/RDFWeaver.java
@@ -1,10 +1,10 @@
 package com.github.jiefenn8.rdfweaver;
 
-import com.github.jiefenn8.graphloom.api.ConfigMaps;
-import com.github.jiefenn8.graphloom.api.InputSource;
-import com.github.jiefenn8.graphloom.rdf.RDFMapper;
 import com.github.jiefenn8.rdfweaver.output.RDFOutput;
 import com.github.jiefenn8.rdfweaver.server.ServerOption;
+import io.github.jiefenn8.graphloom.api.ConfigMaps;
+import io.github.jiefenn8.graphloom.api.InputSource;
+import io.github.jiefenn8.graphloom.rdf.RDFMapper;
 import org.apache.jena.rdf.model.Model;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -80,12 +80,12 @@ public class RDFWeaver implements Callable<Boolean> {
      *
      * @param cmd the commandline and its subcommand to print usage
      */
-    private void recursivelyPrintUsage(CommandLine cmd){
+    private void recursivelyPrintUsage(CommandLine cmd) {
         PrintWriter writer = cmd.getOut();
         cmd.getOut().println();
         LOGGER.info("Printing usage for {}", cmd.getCommandName());
         cmd.usage(writer);
-        cmd.getSubcommands().forEach((k,v)->{
+        cmd.getSubcommands().forEach((k, v) -> {
             recursivelyPrintUsage(v);
         });
     }

--- a/src/main/java/com/github/jiefenn8/rdfweaver/r2rml/R2RMLOption.java
+++ b/src/main/java/com/github/jiefenn8/rdfweaver/r2rml/R2RMLOption.java
@@ -1,8 +1,8 @@
 package com.github.jiefenn8.rdfweaver.r2rml;
 
-import com.github.jiefenn8.graphloom.rdf.parser.R2RMLBuilder;
-import com.github.jiefenn8.graphloom.rdf.r2rml.R2RMLMap;
 import com.github.jiefenn8.rdfweaver.output.OutputOption;
+import io.github.jiefenn8.graphloom.rdf.parser.R2RMLBuilder;
+import io.github.jiefenn8.graphloom.rdf.r2rml.R2RMLMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.n3.turtle.TurtleParseException;
 import org.apache.jena.shared.NotFoundException;

--- a/src/main/java/com/github/jiefenn8/rdfweaver/server/RelationalSource.java
+++ b/src/main/java/com/github/jiefenn8/rdfweaver/server/RelationalSource.java
@@ -64,9 +64,7 @@ public class RelationalSource implements InputSource {
         try (ResultSet results = stmt.executeQuery(query)) {
             LOGGER.debug("Applying actions to query results.");
             EntityResult entityResult = new SQLAdapter(results);
-            while (entityResult.hasNext()) {
-                action.accept(entityResult);
-            }
+            action.accept(entityResult);
         }
     }
 

--- a/src/main/java/com/github/jiefenn8/rdfweaver/server/SQLAdapter.java
+++ b/src/main/java/com/github/jiefenn8/rdfweaver/server/SQLAdapter.java
@@ -1,0 +1,47 @@
+package com.github.jiefenn8.rdfweaver.server;
+
+import io.github.jiefenn8.graphloom.api.inputsource.Entity;
+import io.github.jiefenn8.graphloom.api.inputsource.EntityResult;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * This class defines the base methods in pro
+ */
+public class SQLAdapter implements EntityResult, Entity {
+
+    private static final Logger LOGGER = LogManager.getLogger(SQLAdapter.class);
+    private final ResultSet resultSet;
+
+    protected SQLAdapter(ResultSet resultSet) {
+        this.resultSet = resultSet;
+    }
+
+    @Override
+    public boolean hasNext() {
+        try {
+            return !resultSet.isAfterLast();
+        } catch (SQLException ex) {
+            LOGGER.fatal("Error retrieving next row of entity result.");
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public Entity nextEntity() {
+        return this;
+    }
+
+    @Override
+    public String getPropertyValue(String name) {
+        try {
+            return resultSet.getString(name);
+        } catch (SQLException ex) {
+            LOGGER.fatal("Error retrieving property value {}.", name);
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/github/jiefenn8/rdfweaver/server/SQLAdapter.java
+++ b/src/main/java/com/github/jiefenn8/rdfweaver/server/SQLAdapter.java
@@ -9,13 +9,19 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
- * This class defines the base methods in pro
+ * This class defines the base methods in wrapping the functionality of SQL
+ * for the {@link EntityResult} and {@link Entity} interfaces.
  */
 public class SQLAdapter implements EntityResult, Entity {
 
     private static final Logger LOGGER = LogManager.getLogger(SQLAdapter.class);
     private final ResultSet resultSet;
 
+    /**
+     * Constructs an instance of SQLAdapter with the given ResultSet.
+     *
+     * @param resultSet to wrap its functionality
+     */
     protected SQLAdapter(ResultSet resultSet) {
         this.resultSet = resultSet;
     }

--- a/src/main/java/com/github/jiefenn8/rdfweaver/server/SQLHelper.java
+++ b/src/main/java/com/github/jiefenn8/rdfweaver/server/SQLHelper.java
@@ -1,7 +1,10 @@
 package com.github.jiefenn8.rdfweaver.server;
 
+import io.github.jiefenn8.graphloom.api.EntityReference;
+import io.github.jiefenn8.graphloom.rdf.r2rml.DatabaseType;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,7 +22,7 @@ public class SQLHelper {
      * @param identifiers the string containing identifiers chained together
      * @return the delimited chain enclosed by brackets: [foo].[foo]
      */
-    public static String delimitIdentifier(@NonNull String identifiers) {
+    private static String delimitIdentifier(@NonNull String identifiers) {
         String[] objects = identifiers.split("[.]");
         for (String obj : objects) {
             identifiers = identifiers.replace(obj, "[" + obj + "]");
@@ -28,19 +31,35 @@ public class SQLHelper {
     }
 
     /**
-     * Checks the query String and delimit any objects or identifiers
+     * Checks the query string and delimit any objects or identifiers
      * found so that any conflicts with SQL keywords is unlikely during
      * execution.
      *
      * @param query the string to check and delimit
      * @return the delimited query string ready for use
      */
-    public static String delimitQueryIdentifiers(@NonNull String query) {
+    protected static String delimitQueryIdentifiers(@NonNull String query) {
         Matcher matcher = DB_OBJ_CHAIN_PATTERN.matcher(query);
         while (matcher.find()) {
             String replace = delimitIdentifier(matcher.group(1));
             query = query.replace(matcher.group(1), replace);
         }
         return query;
+    }
+
+    /**
+     * Returns a query string that is prepared to be executed over a SQL
+     * connection.
+     *
+     * @param entityReference containing information to locate a specific entity
+     * @return string of the prepared query
+     */
+    protected static String prepareQuery(EntityReference entityReference) {
+        String query = Objects.requireNonNull(entityReference.getPayload());
+        EntityReference.PayloadType type = entityReference.getPayloadType();
+        if (type.equals(DatabaseType.TABLE_NAME)) {
+            query = "SELECT * FROM " + query;
+        }
+        return SQLHelper.delimitQueryIdentifiers(query);
     }
 }

--- a/src/test/java/com/github/jiefenn8/rdfweaver/output/FileResolverTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/output/FileResolverTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 /**
- * Unit test class for {@code FileResolver}.
+ * Unit test class for {@link FileResolver}.
  */
 public class FileResolverTest {
 

--- a/src/test/java/com/github/jiefenn8/rdfweaver/output/OutputOptionTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/output/OutputOptionTest.java
@@ -29,7 +29,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Unit test class for {@code OutputOption}.
+ * Unit test class for {@link OutputOption}.
  */
 @RunWith(JUnitParamsRunner.class)
 public class OutputOptionTest {

--- a/src/test/java/com/github/jiefenn8/rdfweaver/output/OutputOptionTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/output/OutputOptionTest.java
@@ -3,7 +3,6 @@ package com.github.jiefenn8.rdfweaver.output;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.jena.riot.RDFFormat;
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,8 +25,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/com/github/jiefenn8/rdfweaver/output/RDFFileSystemTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/output/RDFFileSystemTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Unit test class for {@code RDFFile}.
+ * Unit test class for {@link RDFFileSystem}.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RDFFileSystemTest {

--- a/src/test/java/com/github/jiefenn8/rdfweaver/output/RDFOutputFactoryTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/output/RDFOutputFactoryTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
- * Unit test class for {@code RDFFileFactory}.
+ * Unit test class for {@link RDFOutputFactory}.
  */
 public class RDFOutputFactoryTest {
 

--- a/src/test/java/com/github/jiefenn8/rdfweaver/r2rml/R2MRLOptionTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/r2rml/R2MRLOptionTest.java
@@ -1,10 +1,10 @@
 package com.github.jiefenn8.rdfweaver.r2rml;
 
-import com.github.jiefenn8.graphloom.api.EntityMap;
-import com.github.jiefenn8.graphloom.rdf.parser.R2RMLBuilder;
-import com.github.jiefenn8.graphloom.rdf.r2rml.R2RMLMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.github.jiefenn8.graphloom.api.EntityMap;
+import io.github.jiefenn8.graphloom.rdf.parser.R2RMLBuilder;
+import io.github.jiefenn8.graphloom.rdf.r2rml.R2RMLMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.jena.n3.turtle.TurtleParseException;

--- a/src/test/java/com/github/jiefenn8/rdfweaver/server/RelationalSourceTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/server/RelationalSourceTest.java
@@ -1,5 +1,6 @@
 package com.github.jiefenn8.rdfweaver.server;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +37,6 @@ public class RelationalSourceTest {
     private static final String TEST_USER = "test_user";
     private static final String TEST_PASS = "test_pass";
 
-    @Rule public final ExpectedException expectedException = ExpectedException.none();
     @Mock private DataSourceFactory mockDataSourceFactory;
     @Mock private InetAddress mockAddress;
     private RelationalSource.Builder relationalSourceBuilder;
@@ -61,10 +61,14 @@ public class RelationalSourceTest {
     @Test
     public void GivenInvalidParams_WhenBuild_ThenThrowException() {
         when(mockDataSourceFactory.getDataSource(any(Properties.class))).thenThrow(RuntimeException.class);
-        expectedException.expect(Exception.class);
-        relationalSourceBuilder.newInstance()
-                .serverHost(TEST_DRIVER, mockAddress, -1)
-                .credential(TEST_USER, TEST_PASS.toCharArray())
-                .build();
+        Assert.assertThrows(
+                Exception.class,
+                ()-> {
+                    relationalSourceBuilder.newInstance()
+                            .serverHost(TEST_DRIVER, mockAddress, -1)
+                            .credential(TEST_USER, TEST_PASS.toCharArray())
+                            .build();
+                }
+        );
     }
 }

--- a/src/test/java/com/github/jiefenn8/rdfweaver/server/RelationalSourceTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/server/RelationalSourceTest.java
@@ -20,6 +20,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit test class for {@link RelationalSource}.
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class RelationalSourceTest {
 

--- a/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLAdapterTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLAdapterTest.java
@@ -16,6 +16,9 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit test class for {@link SQLAdapter}.
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class SQLAdapterTest extends TestCase {
 

--- a/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLAdapterTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLAdapterTest.java
@@ -1,0 +1,78 @@
+package com.github.jiefenn8.rdfweaver.server;
+
+import io.github.jiefenn8.graphloom.api.inputsource.Entity;
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SQLAdapterTest extends TestCase {
+
+    @Mock
+    private ResultSet mockResultSet;
+    private SQLAdapter SQLAdapter;
+
+    @Before
+    public void SetUp() {
+        SQLAdapter = new SQLAdapter(mockResultSet);
+    }
+
+    @Test
+    public void GivenResultSetHasNext_WhenHasNext_ThenReturnTrue() throws Exception {
+        when(mockResultSet.isAfterLast()).thenReturn(false);
+        boolean result = SQLAdapter.hasNext();
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void GivenResultSetHasNoNext_WhenHasNext_ThenReturnFalse() throws Exception {
+        when(mockResultSet.isAfterLast()).thenReturn(true);
+        boolean result = SQLAdapter.hasNext();
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void GivenResultSetHasException_WhenHasNext_ThenThrowRuntimeException() throws Exception {
+        when(mockResultSet.isAfterLast()).thenThrow(SQLException.class);
+        Assert.assertThrows(
+                RuntimeException.class,
+                () -> SQLAdapter.hasNext()
+        );
+    }
+
+    @Test
+    public void GivenResultSetHasEntity_WhenNextEntity_ThenReturnEntity() {
+        Entity result = SQLAdapter.nextEntity();
+        assertThat(result, instanceOf(Entity.class));
+    }
+
+    @Test
+    public void GivenPropertyName_WhenGetPropertyValue_ThenReturnExpected() throws Exception {
+        String property = "PROPERTY";
+        String expected = "VALUE";
+        when(mockResultSet.getString(property)).thenReturn(expected);
+        String result = SQLAdapter.getPropertyValue(property);
+        assertThat(result, is(equalTo(expected)));
+    }
+
+    @Test
+    public void GivenInvalidPropertyName_WhenGetPropertyValue_ThenThrowRuntimeException() throws Exception {
+        when(mockResultSet.getString(null)).thenThrow(SQLException.class);
+        Assert.assertThrows(
+                RuntimeException.class,
+                () -> SQLAdapter.getPropertyValue(null)
+        );
+    }
+
+}

--- a/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLHelperTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLHelperTest.java
@@ -1,0 +1,46 @@
+package com.github.jiefenn8.rdfweaver.server;
+
+import io.github.jiefenn8.graphloom.api.EntityReference;
+import io.github.jiefenn8.graphloom.rdf.r2rml.DatabaseType;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SQLHelperTest {
+
+    @Test
+    public void GivenObjectChain_WhenDelimitQuery_ThenReturnExpected() {
+        String value = "object.table";
+        String expected = "[object].[table]";
+        String result = SQLHelper.delimitQueryIdentifiers(value);
+        assertThat(result, is(equalTo(expected)));
+    }
+
+    @Test
+    public void GivenValidTableReference_WhenPrepareQuery_ThenReturnExpected() {
+        EntityReference mockEntityRef = mock(EntityReference.class);
+        String payload = "OBJECT.TABLE";
+        when(mockEntityRef.getPayload()).thenReturn(payload);
+        EntityReference.PayloadType payloadType = DatabaseType.TABLE_NAME;
+        when(mockEntityRef.getPayloadType()).thenReturn(payloadType);
+        String expected = "SELECT * FROM [OBJECT].[TABLE]";
+        String result = SQLHelper.prepareQuery(mockEntityRef);
+        assertThat(result, is(equalTo(expected)));
+    }
+
+    @Test
+    public void GivenValidViewReference_WhenPrepareQuery_ThenReturnExpected() {
+        EntityReference mockEntityRef = mock(EntityReference.class);
+        String payload = "SELECT COL (SELECT COUNT(*) FROM OBJ1 WHERE OBJ1.COL=OBJ2.COL) AS S1 FROM OBJ2;";
+        when(mockEntityRef.getPayload()).thenReturn(payload);
+        EntityReference.PayloadType payloadType = DatabaseType.QUERY;
+        when(mockEntityRef.getPayloadType()).thenReturn(payloadType);
+        String expected = "SELECT COL (SELECT COUNT(*) FROM OBJ1 WHERE [OBJ1].[COL]=[OBJ2].[COL]) AS S1 FROM OBJ2;";
+        String result = SQLHelper.prepareQuery(mockEntityRef);
+        assertThat(result, is(equalTo(expected)));
+    }
+}

--- a/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLHelperTest.java
+++ b/src/test/java/com/github/jiefenn8/rdfweaver/server/SQLHelperTest.java
@@ -10,6 +10,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit test class for {@link SQLHelper}.
+ */
 public class SQLHelperTest {
 
     @Test


### PR DESCRIPTION
Why
- Due to Bintray closing, causing old versions of GraphLoom to  be unreachable.

How
- Update build scripts dependencies.
- Update to Java 15.
- Update code base to new changes in v0.5.

Acceptance
- Unit and integration test are successful.
- All PR checks are successful.